### PR TITLE
change timing parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+2.0.2
+#####
+- Fix default duration of network search
+- Fix default interval for time synchronization events
+
+
 2.0.1
 #####
 - Document minimum Pupil Invisible Companion version required (v1.4.14)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 2.0.2
 #####
-- Fix default duration of network search
-- Fix default interval for time synchronization events
+- Fix default duration of network search (10 seconds)
+- Fix default interval for time synchronization events (60 seconds)
 
 
 2.0.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,6 @@
 - Fix default duration of network search (10 seconds)
 - Fix default interval for time synchronization events (60 seconds)
 
-
 2.0.1
 #####
 - Document minimum Pupil Invisible Companion version required (v1.4.14)

--- a/src/pupil_labs/invisible_lsl_relay/cli.py
+++ b/src/pupil_labs/invisible_lsl_relay/cli.py
@@ -87,7 +87,7 @@ def evaluate_user_input(user_input, device_list):
 @click.command()
 @click.option(
     "--time_sync_interval",
-    default=10,
+    default=60,
     help=(
         "Interval in seconds at which time-sync events are sent. "
         "Set to 0 to never send events."
@@ -95,7 +95,7 @@ def evaluate_user_input(user_input, device_list):
 )
 @click.option(
     "--timeout",
-    default=60,
+    default=10,
     help="Time limit in seconds to try to connect to the device",
 )
 @click.option(


### PR DESCRIPTION
The defaults were set incorrectly. Search timeout should be 10 seconds, and the timestamp interval should be 60 seconds. This was inverted.